### PR TITLE
Fix code scanning alert no. 13: Replacement of a substring with itself

### DIFF
--- a/interactions/commands/fun/fun.js
+++ b/interactions/commands/fun/fun.js
@@ -208,8 +208,7 @@ async function execute(interaction) {
       .replace(/V/g, "Λ")
       .replace(/W/g, "M")
       .replace(/X/g, "X")
-      .replace(/Y/g, "⅄")
-      .replace(/Z/g, "Z");
+      .replace(/Y/g, "⅄");
   }
   if (subcommand === "uwu") {
     return interaction.options


### PR DESCRIPTION
Fixes [https://github.com/Ceraia/Discord/security/code-scanning/13](https://github.com/Ceraia/Discord/security/code-scanning/13)

To fix the problem, we need to remove the redundant replacement of 'Z' with 'Z'. This will ensure that the code is clean and free of unnecessary operations. The change should be made in the file `interactions/commands/fun/fun.js` on line 212.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
